### PR TITLE
refresh JWT after profile update and add missing profile translation

### DIFF
--- a/frontend/public/js/auth.js
+++ b/frontend/public/js/auth.js
@@ -273,7 +273,6 @@ class Auth {
   async updateProfile(profileData) {
     try {
       this.showLoader();
-
       const response = await fetch(`${this.baseUrl}/profile`, {
         method: "PUT",
         credentials: "include",
@@ -283,27 +282,15 @@ class Auth {
         },
         body: JSON.stringify(profileData),
       });
-
-      if (!response.ok) {
-        const errorData = await response.json();
-        throw new Error(errorData.message || "Failed to update profile");
-      }
-
-      const updatedUser = await response.json();
-
-      // Update local storage with new user data
+      const { success, message, user: updatedUser } = await response.json();
+      if (!success) throw new Error(message || "Failed to update profile");
       localStorage.setItem("user", JSON.stringify(updatedUser));
       this.user = updatedUser;
-
-      this.showMessage("success", "Profile updated successfully!");
-
-      // Redirect to the dashboard after a short delay
-      setTimeout(() => {
-        window.location.href = "./dashboard";
-      }, 2000);
+      this.showMessage("success", message);
+      window.location.href = "./dashboard";
     } catch (error) {
       console.error("Profile update error:", error);
-      this.showMessage("error", error.message || "Failed to update profile");
+      this.showMessage("error", error.message);
     } finally {
       this.hideLoader();
     }

--- a/frontend/public/js/auth.js
+++ b/frontend/public/js/auth.js
@@ -290,7 +290,10 @@ class Auth {
       window.location.href = "./dashboard";
     } catch (error) {
       console.error("Profile update error:", error);
-      this.showMessage("error", error.message);
+      this.showMessage(
+        "error",
+        error.message || "An unexpected error occurred. Please try again later."
+      );
     } finally {
       this.hideLoader();
     }


### PR DESCRIPTION
## Summary
Fixes an issue where the JWT token was not refreshed after a user updated their profile, causing stale data (like name) to appear in views. Also adds missing translation keys for the profile page.

- Refresh JWT token with updated user data after profile change
- Set new token as HTTP-only cookie
- Add missing i18n keys for profile view/messages